### PR TITLE
AddSwaggerAction: separate interaction with user and business logic

### DIFF
--- a/src/main/groovy/com/smartbear/swagger/AddSwaggerAction.java
+++ b/src/main/groovy/com/smartbear/swagger/AddSwaggerAction.java
@@ -54,15 +54,15 @@ public class AddSwaggerAction extends AbstractSoapUIAction<WsdlProject> {
         if (dialog == null) {
             dialog = ADialogBuilder.buildDialog(Form.class);
             dialog.setValue(Form.TYPE, RESOURCE_LISTING_TYPE);
-            dialog.setValue(Form.DEFAULTMEDIATYPE, SwaggerUtils.DEFAULT_MEDIA_TYPE);
+            dialog.setValue(Form.DEFAULT_MEDIA_TYPE, SwaggerUtils.DEFAULT_MEDIA_TYPE);
         } else {
-            dialog.setValue(Form.SWAGGERURL, "");
+            dialog.setValue(Form.SWAGGER_URL, "");
         }
 
         while (dialog.show()) {
             try {
                 // get the specified URL
-                String url = dialog.getValue(Form.SWAGGERURL).trim();
+                String url = dialog.getValue(Form.SWAGGER_URL).trim();
                 if (StringUtils.hasContent(url)) {
                     // expand any property-expansions
                     String expUrl = PathUtils.expandPath(url, project);
@@ -72,12 +72,9 @@ public class AddSwaggerAction extends AbstractSoapUIAction<WsdlProject> {
                         expUrl = new File(expUrl).toURI().toURL().toString();
                     }
 
-                    SwaggerImporter importer = SwaggerUtils.importSwaggerFromUrl(
-                            project,
-                            expUrl,
+                    importSwaggerDefinition(project, expUrl,
                             dialog.getValue(Form.TYPE).equals(RESOURCE_LISTING_TYPE),
-                            dialog.getValue(Form.DEFAULTMEDIATYPE));
-                    Analytics.trackAction("ImportSwagger", "Importer", importer.getClass().getSimpleName());
+                            dialog.getValue(Form.DEFAULT_MEDIA_TYPE));
                     break;
                 }
             } catch (Exception ex) {
@@ -86,13 +83,23 @@ public class AddSwaggerAction extends AbstractSoapUIAction<WsdlProject> {
         }
     }
 
+    public SwaggerImporter importSwaggerDefinition(final WsdlProject project,
+                                                   final String definitionUrl,
+                                                   final boolean isResourceListing,
+                                                   final String defaultMediaType) throws Exception{
+        SwaggerImporter importer = SwaggerUtils.importSwaggerFromUrl(
+                project, definitionUrl, isResourceListing, defaultMediaType);
+        Analytics.trackAction("ImportSwagger", "Importer", importer.getClass().getSimpleName());
+        return importer;
+    }
+
     @AForm(name = "Add Swagger Definition", description = "Creates a REST API from the specified Swagger definition")
     public interface Form {
         @AField(name = "Swagger Definition", description = "Location or URL of Swagger definition", type = AFieldType.FILE)
-        String SWAGGERURL = "Swagger Definition";
+        String SWAGGER_URL = "Swagger Definition";
 
         @AField(name = "Default Media Type", description = "Default Media Type of the responses", type = AFieldType.STRING)
-        String DEFAULTMEDIATYPE = "Default Media Type";
+        String DEFAULT_MEDIA_TYPE = "Default Media Type";
 
         @AField(name = "Definition Type", description = "Resource Listing or API Declaration",
                 type = AFieldType.RADIOGROUP, values = {RESOURCE_LISTING_TYPE, API_DECLARATION_TYPE})

--- a/src/main/groovy/com/smartbear/swagger/AddSwaggerAction.java
+++ b/src/main/groovy/com/smartbear/swagger/AddSwaggerAction.java
@@ -89,14 +89,14 @@ public class AddSwaggerAction extends AbstractSoapUIAction<WsdlProject> {
     @AForm(name = "Add Swagger Definition", description = "Creates a REST API from the specified Swagger definition")
     public interface Form {
         @AField(name = "Swagger Definition", description = "Location or URL of Swagger definition", type = AFieldType.FILE)
-        public final static String SWAGGERURL = "Swagger Definition";
+        String SWAGGERURL = "Swagger Definition";
 
         @AField(name = "Default Media Type", description = "Default Media Type of the responses", type = AFieldType.STRING)
-        public final static String DEFAULTMEDIATYPE = "Default Media Type";
+        String DEFAULTMEDIATYPE = "Default Media Type";
 
         @AField(name = "Definition Type", description = "Resource Listing or API Declaration",
                 type = AFieldType.RADIOGROUP, values = {RESOURCE_LISTING_TYPE, API_DECLARATION_TYPE})
-        public final static String TYPE = "Definition Type";
+        String TYPE = "Definition Type";
     }
 
 }

--- a/src/main/groovy/com/smartbear/swagger/CreateSwaggerProjectAction.java
+++ b/src/main/groovy/com/smartbear/swagger/CreateSwaggerProjectAction.java
@@ -59,7 +59,6 @@ public class CreateSwaggerProjectAction extends AbstractSoapUIAction<WorkspaceIm
             dialog.setValue(Form.TYPE, RESOURCE_LISTING_TYPE);
             dialog.setValue(Form.DEFAULTMEDIATYPE, SwaggerUtils.DEFAULT_MEDIA_TYPE);
             dialog.getFormField(Form.SWAGGERURL).addFormFieldListener(new XFormFieldListener() {
-                @Override
                 public void valueChanged(XFormField sourceField, String newValue, String oldValue) {
                     initProjectName(newValue);
                 }
@@ -126,17 +125,17 @@ public class CreateSwaggerProjectAction extends AbstractSoapUIAction<WorkspaceIm
     @AForm(name = "Create Swagger Project", description = "Creates a SoapUI Project from the specified Swagger definition")
     public interface Form {
         @AField(name = "Project Name", description = "Name of the project", type = AField.AFieldType.STRING)
-        public final static String PROJECT_NAME = "Project Name";
+        String PROJECT_NAME = "Project Name";
 
         @AField(name = "Swagger Definition", description = "Location or URL of Swagger definition", type = AFieldType.FILE)
-        public final static String SWAGGERURL = "Swagger Definition";
+        String SWAGGERURL = "Swagger Definition";
 
         @AField(name = "Default Media Type", description = "Default Media Type of the responses", type = AFieldType.STRING)
-        public final static String DEFAULTMEDIATYPE = "Default Media Type";
+        String DEFAULTMEDIATYPE = "Default Media Type";
 
         @AField(name = "Definition Type", description = "Resource Listing or API Declaration",
                 type = AFieldType.RADIOGROUP, values = {RESOURCE_LISTING_TYPE, API_DECLARATION_TYPE})
-        public final static String TYPE = "Definition Type";
+        String TYPE = "Definition Type";
     }
 
 }

--- a/src/main/groovy/com/smartbear/swagger/ExportSwaggerAction.java
+++ b/src/main/groovy/com/smartbear/swagger/ExportSwaggerAction.java
@@ -138,22 +138,22 @@ public class ExportSwaggerAction extends AbstractSoapUIAction<WsdlProject> {
     @AForm(name = "Export Swagger Definition", description = "Creates a Swagger definition for selected REST APIs in this project")
     public interface Form {
         @AField(name = "APIs", description = "Select which REST APIs to include in the Swagger definition", type = AFieldType.MULTILIST)
-        public final static String APIS = "APIs";
+        String APIS = "APIs";
 
         @AField(name = "Target Folder", description = "Where to save the Swagger definition", type = AFieldType.FOLDER)
-        public final static String FOLDER = "Target Folder";
+        String FOLDER = "Target Folder";
 
         @AField(name = "API Version", description = "API Version", type = AFieldType.STRING)
-        public final static String VERSION = "API Version";
+        String VERSION = "API Version";
 
         @AField(name = "Base Path", description = "Base Path that the Swagger definition will be hosted on", type = AFieldType.STRING)
-        public final static String BASEPATH = "Base Path";
+        String BASEPATH = "Base Path";
 
         @AField(name = "Swagger Version", description = "Select Swagger version", type = AFieldType.RADIOGROUP, values = {"1.2", "2.0"})
-        public final static String SWAGGER_VERSION = "Swagger Version";
+        String SWAGGER_VERSION = "Swagger Version";
 
         @AField(name = "Format", description = "Select Swagger format", type = AFieldType.RADIOGROUP, values = {"json", "yaml", "xml"})
-        public final static String FORMAT = "Format";
+        String FORMAT = "Format";
     }
 
 }

--- a/src/main/groovy/com/smartbear/swagger/PluginConfig.java
+++ b/src/main/groovy/com/smartbear/swagger/PluginConfig.java
@@ -9,7 +9,7 @@ import com.eviware.soapui.plugins.PluginConfiguration;
 
 @PluginConfiguration(groupId = "com.smartbear.soapui.plugins", name = "Swagger Plugin", version = "2.3.1",
         autoDetect = true, description = "Provides Swagger 1.X/2.0 import/export functionality for REST APIs",
-        infoUrl = "https://github.com/olensmar/soapui-swagger-plugin")
+        infoUrl = "https://github.com/SmartBear/readyapi-swagger-plugin")
 public class PluginConfig extends PluginAdapter {
     @Override
     public void initialize() {

--- a/src/main/groovy/com/smartbear/swagger/SwaggerApiImporter.java
+++ b/src/main/groovy/com/smartbear/swagger/SwaggerApiImporter.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 @PluginApiImporter(label = "Swagger 1.X/2.0")
 public class SwaggerApiImporter implements ApiImporter {
-    @Override
     public List<Interface> importApis(Project project) {
 
         List<Interface> result = new ArrayList<Interface>();

--- a/src/main/groovy/com/smartbear/swagger/SwaggerExporter.java
+++ b/src/main/groovy/com/smartbear/swagger/SwaggerExporter.java
@@ -7,5 +7,5 @@ import com.eviware.soapui.impl.rest.RestService;
  */
 public interface SwaggerExporter {
 
-    public String exportToFolder(String path, String apiVersion, String format, RestService[] services, String basePath);
+    String exportToFolder(String path, String apiVersion, String format, RestService[] services, String basePath);
 }

--- a/src/main/groovy/com/smartbear/swagger/SwaggerImporter.java
+++ b/src/main/groovy/com/smartbear/swagger/SwaggerImporter.java
@@ -6,7 +6,7 @@ import com.eviware.soapui.impl.rest.RestService;
  * Created by ole on 16/09/14.
  */
 public interface SwaggerImporter {
-    public RestService[] importSwagger(String url);
+    RestService[] importSwagger(String url);
 
     RestService importApiDeclaration(String expUrl);
 }

--- a/src/main/groovy/com/smartbear/swagger/SwaggerUtils.groovy
+++ b/src/main/groovy/com/smartbear/swagger/SwaggerUtils.groovy
@@ -64,8 +64,10 @@ class SwaggerUtils {
         return importSwaggerFromUrl(project, finalExpUrl, isResourceListing, "application/json");
     }
 
-    static SwaggerImporter importSwaggerFromUrl(
-            final WsdlProject project, final String finalExpUrl, final boolean isResourceListing, final String defaultMediaType) throws Exception {
+    static SwaggerImporter importSwaggerFromUrl(final WsdlProject project,
+                                                final String finalExpUrl,
+                                                final boolean isResourceListing,
+                                                final String defaultMediaType) throws Exception {
 
         final SwaggerImporter importer = SwaggerUtils.createSwaggerImporter(finalExpUrl, project, defaultMediaType);
 


### PR DESCRIPTION
@olensmar I had to extract business logic since we're working on automatic performance testing and one of the points of the plan is measuring project creation from Swagger definition.

Also this PR contains some cleanups: removed some redundant Override annotations and `public final static` field delcarations.

BTW: I failed to build the plugin by myself since dependency com.smartbear:swagger4j:1.0-beta6 is unresolved.
