### PR TITLE
Expose the "silent" import method to the Ready! API plugin framework

### DIFF
--- a/src/main/groovy/com/smartbear/swagger/CreateSwaggerProjectAction.java
+++ b/src/main/groovy/com/smartbear/swagger/CreateSwaggerProjectAction.java
@@ -42,7 +42,7 @@ import java.io.File;
  */
 
 @PluginImportMethod(label = "Swagger Definition (REST)")
-public class CreateSwaggerProjectAction extends AbstractSoapUIAction<WorkspaceImpl> {
+public class CreateSwaggerProjectAction extends AbstractSoapUIAction<WorkspaceImpl> implements SilentImportMethodRetriever {
     public static final String RESOURCE_LISTING_TYPE = "Resource Listing";
     public static final String API_DECLARATION_TYPE = "API Declaration (Swagger 1.X only)";
 
@@ -119,6 +119,20 @@ public class CreateSwaggerProjectAction extends AbstractSoapUIAction<WorkspaceIm
             if (ix != -1) {
                 dialog.setValue(Form.PROJECT_NAME, newValue.substring(ix + 1));
             }
+        }
+    }
+
+    /**
+     * This method is used by version 1.8.2 and later of Ready! API, where silent import methods exist.
+     * The late binding of the SilentSwaggerImporter class, which implements the new interface SilentImportMethod, is done to
+     * make the plugin backwards-compatible with earlier versions of Ready! API.
+     * @return An instance of SilentSwaggerImporter in modern versions of Ready! API, null in earlier versions
+     */
+    public Object getImportMethod() {
+        try {
+            return Class.forName("com.smartbear.swagger.SilentSwaggerImporter").newInstance();
+        } catch (Exception e) {
+            return null;
         }
     }
 

--- a/src/main/groovy/com/smartbear/swagger/SilentImportMethodRetriever.java
+++ b/src/main/groovy/com/smartbear/swagger/SilentImportMethodRetriever.java
@@ -1,0 +1,13 @@
+package com.smartbear.swagger;
+
+/**
+ * The getImportMethod() must be defined in an interface, or it will not be accessible to the Ready! API plugin framework.
+ */
+public interface SilentImportMethodRetriever {
+
+    /**
+     *  Used by the Ready! API plugin framework to get an instance of SilentSwaggerImporter.
+     */
+    @SuppressWarnings("unused")
+    Object getImportMethod();
+}

--- a/src/main/groovy/com/smartbear/swagger/SilentSwaggerImporter.java
+++ b/src/main/groovy/com/smartbear/swagger/SilentSwaggerImporter.java
@@ -11,7 +11,12 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 
+//Instantiated using reflection
+@SuppressWarnings("unused")
 public class SilentSwaggerImporter implements SilentImportMethod {
+
+    private CreateSwaggerProjectAction createSwaggerProjectAction = new CreateSwaggerProjectAction();
+
     public boolean acceptsURL(URL url) {
         return url.toString().toLowerCase().contains("swagger.");
     }
@@ -19,11 +24,11 @@ public class SilentSwaggerImporter implements SilentImportMethod {
     public Collection<Interface> importApi(URL url, WsdlProject wsdlProject) throws UnsupportedDefinitionException {
         SwaggerImporter importer = SwaggerUtils.createSwaggerImporter(url.toString(), wsdlProject);
         Interface[] services = importer.importSwagger(url.toString());
-        return Arrays.asList( services );
+        return Arrays.asList(services);
     }
 
     public SoapUIAction<WorkspaceImpl> getImportAction() {
-        return new CreateSwaggerProjectAction();
+        return createSwaggerProjectAction;
     }
 
     public String getLabel() {


### PR DESCRIPTION
Along with the most recent changes in Ready! API 1.8.2 (see https://github.com/SmartBear/axm/pull/6117), this will make the "silent" import method visible to the Ready! API framework.

Also includes a small optimisation and some formatting in SilentSwaggerImporter.